### PR TITLE
Add nextline-schedule plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sorunlib==0.1.6
+nextline-schedule==0.0.2


### PR DESCRIPTION
This adds the [nextline-schedule](https://github.com/simonsobs/nextline-schedule) plugin to the so-daq-sequencer-docker image, allowing it to interface with the SO scheduler.