### PR TITLE
Configure local scheduler for testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,6 @@ clean :
 	docker-compose down
 	docker image rm so-daq-sequencer-frontend:latest
 	docker image rm so-daq-sequencer:latest
+	docker image rm so-daq-sequencer-scheduler:latest
 
 # vim: set expandtab!:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,3 +22,13 @@ services:
     container_name: backend
     ports:
       - "8000:8000"
+    environment:
+      - NEXTLINE_SCHEDULE__API=http://scheduler:8010/api/v1/schedule/
+      - NEXTLINE_SCHEDULE__POLICY={"policy":"dummy","config":{}}
+
+  scheduler:
+    build:
+      context: ./
+      dockerfile: scheduler.Dockerfile
+    image: so-daq-sequencer-scheduler:latest
+    container_name: scheduler

--- a/scheduler.Dockerfile
+++ b/scheduler.Dockerfile
@@ -1,0 +1,1 @@
+FROM simonsobs/scheduler-server:a81ecf3


### PR DESCRIPTION
This PR adds a local scheduler to the configuration. This speeds up testing interactions with the scheduler, as those tests no longer rely on the external service spinning up.