### PR TITLE
Add requested timezone packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 sorunlib==0.1.9
 nextline-schedule==0.2.5
+pytz==2023.3.post1
+tzdata==2023.3


### PR DESCRIPTION
This adds `pytz` and `tzdata`. I do want to point out this blurb from `pytz`'s docs (cc @kmharrington):
> Projects using Python 3.9 or later should be using the support now included as part of the standard library, and third party packages work with it such as [tzdata](https://pypi.org/project/tzdata/). pytz offers no advantages beyond backwards compatibility with code written for earlier versions of Python.

We're on Python 3.10 in this container, so I'd also urge using the standard library timezone support, unless we already have a bunch of code dependent on `pytz`.