### PR TITLE
Add `nextline-rdb` in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 sorunlib==0.1.11
 nextline-schedule==0.2.5
 nextline-alert==0.1.1
+nextline-rdb==0.4.0
 tzdata==2023.4


### PR DESCRIPTION
I removed `nextline-rdb` from the depencies of `nextline-graphql` at [v0.7.3](https://github.com/simonsobs/nextline-graphql/releases/tag/v0.7.3).  This PR adds `nextline-rdb` as a requirement here.
