### PR TITLE
Bump several nextline package versions

### DIFF
--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/simonsobs/nextline-graphql:v0.7.7
+FROM ghcr.io/simonsobs/nextline-graphql:v0.7.8
 
 # Setup configuration environment
 ENV OCS_CONFIG_DIR=/config

--- a/frontend.Dockerfile
+++ b/frontend.Dockerfile
@@ -1,1 +1,1 @@
-FROM ghcr.io/simonsobs/nextline-web:v0.9.0
+FROM ghcr.io/simonsobs/nextline-web:v0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sorunlib==0.1.13
-nextline-schedule==0.3.0
+nextline-schedule==0.3.1
 nextline-alert==0.1.4
 nextline-rdb==0.6.6
 tzdata==2024.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sorunlib==0.1.13
 nextline-schedule==0.3.0
 nextline-alert==0.1.4
-nextline-rdb==0.6.5
+nextline-rdb==0.6.6
 tzdata==2024.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sorunlib==0.1.13
 nextline-schedule==0.3.1
-nextline-alert==0.1.4
+nextline-alert==0.1.5
 nextline-rdb==0.6.6
 tzdata==2024.1


### PR DESCRIPTION
Since these all rely on the changes in `nextline-graphql` we need to bump everything at once to have things work. Includes changes from #139, #140, #141, #142, #143.